### PR TITLE
Fix npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "git@github.com:StephenGrider/ReduxSimpleStarter.git",
   "scripts": {
-    "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js"
+    "start": "webpack-dev-server --inline --hot"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
- As explained [here](https://github.com/StephenGrider/ReduxSimpleStarter/issues/4), the relative path is not necessary.
- I added the *hot* and *inline* flags to enable simple hot reloading.