### PR TITLE
Generate sourcemaps with webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,5 +19,6 @@ module.exports = {
   devServer: {
     historyApiFallback: true,
     contentBase: './'
-  }
+  },
+  devtool: 'source-map'
 };


### PR DESCRIPTION
Adding this to my webpack config made debugging a lot easier for me, as devtools shows the line the actual file of the component where the error occurs.

This makes finding typo's and other small mistakes a lot easier (for me at least)

[Before](https://cloud.githubusercontent.com/assets/5508905/14295769/47166812-fb77-11e5-9fc0-46152696c4d7.png)

[After](https://cloud.githubusercontent.com/assets/5508905/14295729/1c51c04a-fb77-11e5-8851-d1870788a77d.png)