### PR TITLE
Add global.navigator to test_helper.js

### DIFF
--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -11,6 +11,7 @@ import reducers from '../src/reducers';
 
 global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
 global.window = global.document.defaultView;
+global.navigator = global.window.navigator;
 const $ = _$(window);
 
 chaiJquery(chai, chai.util, $);


### PR DESCRIPTION
Fix the error, 'navigator is not defined', which happens in testing with react-router link.
```
~/ReduxSimpleStarter/node_modules/history/lib/DOMUtils.js:61

var ua = navigator.userAgent;
           ^
 
ReferenceError: navigator is not defined
```