### PR TITLE
setup jsdom to allow inter-component testing

### DIFF
--- a/test/setup-jsdom.js
+++ b/test/setup-jsdom.js
@@ -1,0 +1,14 @@
+// With this setup, App can be loaded and inter-component actions tested
+
+// First, make jQuery available for jsdom
+import _$ from 'jquery';
+
+// From http://stackoverflow.com/questions/26867535/calling-setstate-in-jsdom-based-tests-causing-cannot-render-markup-in-a-worker
+// by leplatrem
+var jsdom = require("jsdom");
+
+// Setup the jsdom environment
+// @see https://github.com/facebook/react/issues/5046
+global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
+global.window = document.defaultView;
+global.navigator = global.window.navigator;


### PR DESCRIPTION
With this new file, you can now test multiple compoenents, sort of an end-to-end test for App. You can import App and then run  tests that depend on the components included in App, like this:
```
import { renderComponent , expect } from '../test_helper';
import App from '../../src/components/app';

describe('App' , () => {
  let component;
  beforeEach( () => {
    component = renderComponent(App);
  });
  describe('with dynamic list elements', () => {
    let textarea;
    let button;
    beforeEach( () => {
      textarea = component.find('textarea');
      textarea.simulate('change', 'a sample comment');
      button = component.find('button');
      button.simulate('submit');
    });
    it('displays the expected controls', () => {
      console.log('textarea: ', textarea, '\n', 'button: ', button);
      expect(textarea).to.exist;
      expect(button).to.exist;
    });
    it('has an li for comments', () => {
      expect(component.find('li')).to.exist;
    });
    it('displays comment text',() => {
      expect(component.find('li')).to.contain('a sample comment');
    });
  });
});


```