### PR TITLE
Windows File System compatibility issue

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,5 +22,8 @@ module.exports = {
   devServer: {
     historyApiFallback: true,
     contentBase: './'
-  }
+  },
+  plugins: [
+    new webpack.OldWatchingPlugin()
+    ]
 };


### PR DESCRIPTION
Sometimes on Windows File Changes aren't registered with the new plugin, so use the old one.