### PR TITLE
add source-map to make troubleshooting easier

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
   resolve: {
     extensions: ['', '.js', '.jsx']
   },
+  devtool: 'source-map',
   devServer: {
     historyApiFallback: true,
     contentBase: './'


### PR DESCRIPTION
Adding source-map to webpack.config.js gives a more precise path to the file that appears in the console when an error occurs. Without it, the path will always be the webpack generated /bundle.js, which doesn't really help on where to find a potential bug. Having the simple devtool/source-map key-value pair helps to find and fix bugs in a quicker manner.