### PR TITLE
Update bootstrap.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="/style/style.css">
-    <link rel="stylesheet" href="https://cdn.rawgit.com/twbs/bootstrap/v4-dev/dist/css/bootstrap.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.css">
     <script src="https://maps.googleapis.com/maps/api/js"></script>
   </head>
   <body>


### PR DESCRIPTION
The current link's css does not have '-xs-' classes such as .col-xs-* /  .text-xs-right, so it needs to be updated to a proper css link.