### PR TITLE
Expose application from docker container

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = {
     extensions: ['', '.js', '.jsx']
   },
   devServer: {
+    host: '0.0.0.0',
     historyApiFallback: true,
     contentBase: './'
   }


### PR DESCRIPTION
If you just want to use plain and simple docker container to run this application as I do with this command:

```
docker run -it --rm -v ${PWD}:/app -w /app -p 8080:8080 node bash
```

The propagation address `0.0.0.0` need to be exposed. 

This issue was spotted on MacOS