### PR TITLE
Update Jquery Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-preset-react": "^6.1.18",
     "chai": "^3.5.0",
     "chai-jquery": "^2.0.0",
-    "jquery": "^2.2.1",
+    "jquery": "^3.0.0",
     "jsdom": "^8.1.0",
     "mocha": "^2.4.5",
     "react-addons-test-utils": "^0.14.7",


### PR DESCRIPTION
Because of Older Version of Jquery's Dependency Detected by Github and their give us warning to upgrade this Jquery npm version. Just a little change for better future.